### PR TITLE
`getPackageAddress` function for re-packagers

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
@@ -1,17 +1,9 @@
 package com.simibubi.create.compat.computercraft.implementation.peripherals;
 
-import java.lang.reflect.Array;
+
 import java.util.Optional;
 
 import com.simibubi.create.content.logistics.packager.repackager.RepackagerBlockEntity;
-
-import com.simibubi.create.foundation.utility.CreateLang;
-
-import net.createmod.catnip.nbt.NBTHelper;
-import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.screens.multiplayer.WarningScreen;
-
-import net.minecraft.nbt.CompoundTag;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
@@ -1,8 +1,17 @@
 package com.simibubi.create.compat.computercraft.implementation.peripherals;
 
+import java.lang.reflect.Array;
 import java.util.Optional;
 
 import com.simibubi.create.content.logistics.packager.repackager.RepackagerBlockEntity;
+
+import com.simibubi.create.foundation.utility.CreateLang;
+
+import net.createmod.catnip.nbt.NBTHelper;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.screens.multiplayer.WarningScreen;
+
+import net.minecraft.nbt.CompoundTag;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -39,6 +48,12 @@ public class RepackagerPeripheral extends SyncedPeripheral<RepackagerBlockEntity
 		if (blockEntity.heldBox.isEmpty())
 			return false;
 		return true;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final String getPackageAddress() throws LuaException { // Took me a while but this seems to work
+		return blockEntity.heldBox.getOrCreateTag()
+			.getString("Address");
 	}
 
 	@NotNull

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
@@ -52,8 +52,10 @@ public class RepackagerPeripheral extends SyncedPeripheral<RepackagerBlockEntity
 
 	@LuaFunction(mainThread = true)
 	public final String getPackageAddress() throws LuaException { // Took me a while but this seems to work
-		return blockEntity.heldBox.getOrCreateTag()
-			.getString("Address");
+		if (!blockEntity.heldBox.isEmpty())
+			return blockEntity.heldBox.getOrCreateTag()
+				.getString("Address");
+		return null;
 	}
 
 	@NotNull


### PR DESCRIPTION
`getPackageAddress()` returns:
- The address of the package. Special chars work, but Emojis won't since CC doesn't support them.
- An empty string if the package has no address
- `nil` if there's no package found