### PR TITLE
`getPackageAddress()` now uses a different way of reading addresses.

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -102,6 +102,15 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
 	}
 
 	@LuaFunction(mainThread = true)
+	public final void setPackageAddress(Optional<String> argument) {
+		if (argument.isPresent()) {
+			PackageItem.addAddress(blockEntity.heldBox, argument.get());
+		} else {
+			PackageItem.addAddress(blockEntity.heldBox, "");
+		}
+	}
+
+	@LuaFunction(mainThread = true)
 	public final Map<Integer, Map<String, ?>> getPackageItems() throws LuaException {
 		ItemStack box = blockEntity.heldBox;
 		if (box.isEmpty() && !PackageItem.isPackage(box))

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -102,12 +102,16 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
 	}
 
 	@LuaFunction(mainThread = true)
-	public final void setPackageAddress(Optional<String> argument) {
-		if (argument.isPresent()) {
-			PackageItem.addAddress(blockEntity.heldBox, argument.get());
-		} else {
-			PackageItem.addAddress(blockEntity.heldBox, "");
+	public final boolean setPackageAddress(Optional<String> argument) {
+		if (!blockEntity.heldBox.isEmpty()) {
+			if (argument.isPresent()) {
+				PackageItem.addAddress(blockEntity.heldBox, argument.get());
+			} else {
+				PackageItem.addAddress(blockEntity.heldBox, "");
+			}
+			return true;
 		}
+		return false;
 	}
 
 	@LuaFunction(mainThread = true)

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
@@ -67,11 +67,19 @@ public class RepackagerPeripheral extends SyncedPeripheral<RepackagerBlockEntity
 	}
 
 	@LuaFunction(mainThread = true)
-	public final String getPackageAddress() throws LuaException { // Took me a while but this seems to work
+	public final String getPackageAddress() throws LuaException {
 		if (!blockEntity.heldBox.isEmpty())
-			return blockEntity.heldBox.getOrCreateTag()
-					.getString("Address");
+			return PackageItem.getAddress(blockEntity.heldBox);
 		return null;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final void setPackageAddress(Optional<String> argument) {
+		if (argument.isPresent()) {
+			PackageItem.addAddress(blockEntity.heldBox, argument.get());
+		} else {
+			PackageItem.addAddress(blockEntity.heldBox, "");
+		}
 	}
 
 	@LuaFunction(mainThread = true)

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
@@ -74,12 +74,16 @@ public class RepackagerPeripheral extends SyncedPeripheral<RepackagerBlockEntity
 	}
 
 	@LuaFunction(mainThread = true)
-	public final void setPackageAddress(Optional<String> argument) {
-		if (argument.isPresent()) {
-			PackageItem.addAddress(blockEntity.heldBox, argument.get());
-		} else {
-			PackageItem.addAddress(blockEntity.heldBox, "");
+	public final boolean setPackageAddress(Optional<String> argument) {
+		if (!blockEntity.heldBox.isEmpty()) {
+			if (argument.isPresent()) {
+				PackageItem.addAddress(blockEntity.heldBox, argument.get());
+			} else {
+				PackageItem.addAddress(blockEntity.heldBox, "");
+			}
+			return true;
 		}
+		return false;
 	}
 
 	@LuaFunction(mainThread = true)


### PR DESCRIPTION
Adding the `setPackageAddress()` function to packagers and re-packagers.
And changing the way `getPackageAddress()` reads addresses.