### PR TITLE
Made stock ticker requesting work with any arbitrary data from item details

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerUtil.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerUtil.java
@@ -1,165 +1,200 @@
 package com.simibubi.create.compat.computercraft.implementation;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
 
+import com.simibubi.create.Create;
 import com.simibubi.create.content.logistics.BigItemStack;
 
 import dan200.computercraft.api.detail.VanillaDetailRegistries;
 import dan200.computercraft.api.lua.LuaException;
-
-import net.minecraft.world.item.ItemStack;
-
 import net.minecraftforge.items.IItemHandler;
-
-import org.jetbrains.annotations.NotNull;
 
 public class ComputerUtil {
 
-	// tldr: the computercraft api lets you parse items into lua-like-tables that cc
-	// uses for all it's items. to keep consistency with the rest of the inventory
-	// api in other parts of the mod i must do this terribleness. i am sorry.
-	public static int bigItemStackToLuaTableFilter(BigItemStack entry, Map<?, ?> filter) throws LuaException {
-		Map<String, Object> details = new HashMap<>(
-				VanillaDetailRegistries.ITEM_STACK.getDetails(entry.stack));
-		details.put("count", entry.count);
-		if (filter.containsKey("name"))
-			if (filter.get("name") instanceof String) {
-				String filterName = (String) filter.get("name");
-				if (!filterName.contains(":"))
-					filterName = "minecraft:" + filterName;
-				if (!filterName.equals(details.get("name")))
-					return 0;
-			} else {
-				throw new LuaException("Name must be a string");
-			}
-		// check the easy types
-		Map<String, Class<?>> expectedTypes = new HashMap<>();
-		expectedTypes.put("displayName", String.class);
-		expectedTypes.put("nbt", String.class);
-		expectedTypes.put("damage", Double.class);
-		expectedTypes.put("durability", Double.class);
-		expectedTypes.put("maxDamage", Double.class);
-		expectedTypes.put("maxCount", Double.class);
-		for (String key : expectedTypes.keySet()) {
-			if (filter.containsKey(key)) {
-				Object filterValue = filter.get(key);
-				Class<?> expectedType = expectedTypes.get(key);
-				if (expectedType.isInstance(filterValue)) {
-					Object detailsValue = details.get(key);
-					// some of these values are ints sometimes :tf:
-					if (expectedType == Double.class && detailsValue instanceof Number) {
-						detailsValue = ((Number) detailsValue).doubleValue();
-					}
-					if (!details.containsKey(key) || !filterValue.equals(detailsValue)) {
-						return 0;
-					}
-				} else {
-					throw new LuaException(key + " must be a " + expectedType.getSimpleName());
-				}
-			}
-		}
-		// java types dont mix well with lua tables at all
-		if (filter.containsKey("tags")) {
-			Object filterTagsObject = filter.get("tags");
-			Object itemTagsObject = details.get("tags");
-			if (filterTagsObject instanceof Map<?, ?> && itemTagsObject instanceof Map<?, ?>) {
-				@SuppressWarnings("unchecked")
-				Map<String, Boolean> filterTags = (Map<String, Boolean>) filterTagsObject;
-				@SuppressWarnings("unchecked")
-				Map<String, Boolean> itemTags = (Map<String, Boolean>) itemTagsObject;
-				for (Map.Entry<String, Boolean> filterTagEntry : filterTags.entrySet()) {
-					if (!(filterTagEntry.getValue() instanceof Boolean)) {
-						throw new LuaException(
-							"Tags filter must be a table of tags like: \n{tags = { \n	[\"minecraft:logs\"] = true} \n	{diamonds = true}\n}}");
-					}
-					int filterMatches = 0;
-					for (Map.Entry<String, Boolean> itemTagEntry : itemTags.entrySet()) {
-						if (itemTagEntry.getKey().equals(filterTagEntry.getKey())) {
-							filterMatches++;
-						}
-					}
-					if (filterMatches == 0) {
-						return 0;
-					}
-				}
-			} else {
-				return 0;
-			}
-		}
-		// avert your eyes, it only gets worse. When the computercraft api fetches
-		// enchants of an item, it's an array list. when you submit a table from within
-		// computercraft as an argument, it's always a hash map. Handling the mix of
-		// both instead of converting because i felt like it's a good idea
-		if (filter.containsKey("enchantments")) {
-			Object filterEnchantmentsObject = filter.get("enchantments"); // HashMap
-			Object itemEnchantmentsObject = details.get("enchantments"); // ArrayList
-			// i might be doing a major skill issue here, idk i mainly do development in lua
-			if (filterEnchantmentsObject instanceof Map<?, ?> && itemEnchantmentsObject instanceof ArrayList<?>) {
-				@SuppressWarnings("unchecked")
-				Map<String, Map<String, ?>> filterEnchantments = (Map<String, Map<String, ?>>) filterEnchantmentsObject;
-				@SuppressWarnings("unchecked")
-				ArrayList<HashMap<String, ?>> itemEnchantments = (ArrayList<HashMap<String, ?>>) itemEnchantmentsObject;
-				if (filterEnchantments.size() != itemEnchantments.size())
-					return 0;
-				Set<HashMap<String, ?>> matchedItemEnchantments = new HashSet<>();
-				for (Map.Entry<String, ?> filterEnchantmentNode : filterEnchantments.entrySet()) {
-					int filterMatches = 0;
-					if (!(filterEnchantmentNode.getValue() instanceof Map<?, ?>)) {
-						throw new LuaException(
-							"Enchantments filter must be a table of enchant information like: \n{enchantments = { \n	{name = \"minecraft:sharpness\"} \n	{name = \"minecraft:protection\" \n level = 1\n	}\n}}");
-					}
-					@SuppressWarnings("unchecked")
-					Map<String, ?> filterEnchantmentEntry = (Map<String, ?>) (filterEnchantmentNode.getValue());
-					String filterEnchantmentName = (String) (filterEnchantmentEntry.get("name"));
-					String filterEnchantmentDisplayName = (String) (filterEnchantmentEntry.get("displayName"));
-					Double filterEnchantmentLevel = 0.0;
-					boolean CheckEnchantmentName = false;
-					boolean CheckEnchantmentDisplayName = false;
-					boolean CheckEnchantmentLevel = false;
-					if (filterEnchantmentEntry.get("level") instanceof Double) {
-						filterEnchantmentLevel = (Double) (filterEnchantmentEntry.get("level"));
-						CheckEnchantmentLevel = true;
-					}
-					if (filterEnchantmentEntry.get("name") instanceof String) {
-						filterEnchantmentName = (String) (filterEnchantmentEntry.get("name"));
-						CheckEnchantmentName = true;
-					}
-					if (filterEnchantmentEntry.get("displayName") instanceof String) {
-						filterEnchantmentDisplayName = (String) (filterEnchantmentEntry.get("displayName"));
-						CheckEnchantmentDisplayName = true;
-					}
-					for (HashMap<String, ?> itemEnchantmentEntry : itemEnchantments) {
-						String itemEnchantmentName = (String) itemEnchantmentEntry.get("name");
-						String itemEnchantmentDisplayName = (String) (itemEnchantmentEntry.get("displayName"));
-						Integer itemEnchantmentLevel = (Integer) (itemEnchantmentEntry.get("level"));
+  public static int bigItemStackToLuaTableFilter(BigItemStack entry, Map<String,Object> filter) throws LuaException {
 
-						if (!matchedItemEnchantments.contains(itemEnchantmentEntry)
-							&& (!CheckEnchantmentName || itemEnchantmentName.equals(filterEnchantmentName))
-							&& (!CheckEnchantmentDisplayName
-							|| (itemEnchantmentDisplayName.equals(filterEnchantmentDisplayName)))
-							&& (!CheckEnchantmentLevel
-							|| (itemEnchantmentLevel
-							.doubleValue()) == filterEnchantmentLevel)) {
-							matchedItemEnchantments.add(itemEnchantmentEntry); // one itemenchant per filter
-							filterMatches++;
-						}
-					}
-					if (filterMatches == 0) {
-						return 0;
-					}
-				}
-			} else {
-				return 0;
-			}
-		}
-		return entry.count;
+    Map<String,Object> details =
+      new HashMap<>(VanillaDetailRegistries.ITEM_STACK.getDetails(entry.stack));
+    //details.put("count", entry.count);
 
-	}
+    // If name is in filter and doesn't have : in it add minecraft: namespace
+    if (filter.containsKey("name") && filter.get("name") instanceof String name) {
+      if (!name.contains(":")) {
+        details.put("name", "minecraft:" + name);
+      }
+    }
 
+    // If filter is a list, check if the item is in the list
+    Collection fColl = Collection.of(filter);
+    if (fColl == null || !fColl.isMap())
+      throw new LuaException("Filter must be a map");
+
+    Collection iColl = Collection.of(details);
+    if (!matchMap(fColl, iColl))
+      return 0;
+    return entry.count;
+  }
+
+  private static boolean deepEquals(Object fVal, Object iVal) throws LuaException {
+    // Checks primitives, strings and booleans
+    if (Objects.equals(fVal, iVal)) return true;
+
+    // If both are numbers, compare them as doubles because lua numbers are always doubles
+    if (fVal instanceof Number fn && iVal instanceof Number in){
+      return Double.compare(fn.doubleValue(), in.doubleValue()) == 0;}
+
+    // Convert to collections
+    Collection fColl = Collection.of(fVal);
+    Collection iColl = Collection.of(iVal);
+    // If one is not a collection, return false
+    if (fColl == null || iColl == null)
+      return false;
+    
+    // Compare as list or map
+    if (iColl.isList() && fColl.isList()) return matchList(fColl, iColl);
+    if (iColl.isMap()  && fColl.isMap())  return matchMap (fColl, iColl);
+    return false;                                         
+  }
+
+  private static boolean matchList(Collection f, Collection i) throws LuaException {
+    switch (f.mode) {
+      case EXACT -> {
+        if (f.list.size() != i.list.size()) return false;
+        for (int k = 0; k < f.list.size(); k++)
+          if (!deepEquals(f.list.get(k), i.list.get(k))) 
+            return false;
+        return true;
+      }
+      case CONTAINS   -> {
+        outer: for (Object fVal : f.list) {
+          for (Iterator<?> it = i.list.iterator(); it.hasNext();) {
+            Object iVal = it.next();
+            if (deepEquals(fVal, iVal)) { it.remove(); continue outer; }
+          }
+          return false;
+        }
+        return true;
+      }
+      case CONTAINED  -> 
+      {
+        outer: for (Object iVal : i.list) {
+          for (Iterator<?> it = f.list.iterator(); it.hasNext();) {
+            Object fVal = it.next();
+            if (deepEquals(fVal, iVal)) { it.remove(); continue outer; }
+          }
+          return false;
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean matchMap(Collection f, Collection i) throws LuaException {
+    switch (f.mode) {
+      case EXACT -> {
+        if (!f.map.keySet().equals(i.map.keySet())) return false;
+        for (var e : f.map.entrySet()) {
+          if (!deepEquals(e.getValue(), i.map.get(e.getKey())))
+            return false;
+        }
+        return true;
+      }
+      case CONTAINS -> {
+        for (var e : f.map.entrySet()) {
+          if (!i.map.containsKey(e.getKey())
+              || !deepEquals(e.getValue(), i.map.get(e.getKey())))
+            return false;
+        }
+        return true;
+      }
+      case CONTAINED -> {
+        for (var e : i.map.entrySet()) {
+          if (!f.map.containsKey(e.getKey())
+              || !deepEquals(f.map.get(e.getKey()), e.getValue()))
+            return false;
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Is a wrapper for lua tables so they can be processed as lists or maps
+  private record Collection(MatchMode mode, List<?> list, Map<?, ?> map) {
+    boolean isList() { return list != null; }
+    boolean isMap()  { return map != null; }
+
+    // Returns null if not a list or map
+    static Collection of(Object o) throws LuaException {
+      if (o instanceof Map<?,?> m) {
+        MatchMode mode = MatchMode.parse(m.get("_mode"));
+        m.remove("_mode");
+        if (isArrayLike(m)) {
+          List<Object> lst = toOrderedList(m);
+          return new Collection(mode, lst, m);
+        }
+        return new Collection(mode, null, m);
+      }
+      // List for CC, never from filter
+      if (o instanceof List<?> raw) {
+        return new Collection(MatchMode.CONTAINS, raw, null);
+      }
+      return null;
+    }
+  }
+
+  // Allows user to specify match mode in filter for the specific list or map
+  // Exact: 1:1 match, list must be same size and order
+  // Contains: All elements in filter must be in the item, order doesn't matter, args removed from filter as they are found
+  // Contained: All elements in item must be in the filter, order doesn't matter, args removed from item as they are found
+  private enum MatchMode { EXACT, CONTAINS, CONTAINED;
+    static MatchMode parse(Object t) throws LuaException {
+      if (!(t instanceof String s)) return CONTAINS;
+      return switch (s.toLowerCase()) {
+        case "exact"     -> EXACT;
+        case "contains"  -> CONTAINS;
+        case "contained" -> CONTAINED;
+        default          -> throw new LuaException(
+          "Invalid match mode: " + s + ", expected 'exact', 'contained' or 'contains'");
+      };
+    }
+  }
+
+  // All arrays from lua are passed as maps so we check if it is an array-like map
+  private static boolean isArrayLike(Map<?,?> map) {
+    int n = map.size();
+    if (n == 0) return true;
+
+    boolean[] seen = new boolean[n];
+    for (Object keyObj : map.keySet()) {
+      if (!(keyObj instanceof Number)) return false;
+      int k = ((Number) keyObj).intValue() - 1;
+      if (k != Math.floor(k)) return false; // not an whole number
+      if (k < 0 || k >= n || seen[k]) return false;
+      seen[k] = true;
+    }
+
+    for (boolean ok : seen)  
+      if (!ok) return false;
+
+    return true;
+  }
+
+  private static List<Object> toOrderedList(Map<?,?> m) {
+    int n = m.size();
+    List<Object> out = new ArrayList<>(Collections.nCopies(n, null));
+    for (var e : m.entrySet())
+      out.set(((Number) e.getKey()).intValue() - 1, e.getValue());
+    return out;
+  }
+  
 	public static Map<Integer, Map<String, ?>> list(IItemHandler inventory) {
 		Map<Integer, Map<String, ?>> result = new HashMap<>();
 		var size = inventory.getSlots();

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerUtil.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerUtil.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.simibubi.create.Create;
 import com.simibubi.create.content.logistics.BigItemStack;
 
 import dan200.computercraft.api.detail.VanillaDetailRegistries;
@@ -31,12 +30,10 @@ public class ComputerUtil {
     }
 
     // If filter is a list, check if the item is in the list
-    Collection fColl = Collection.of(filter);
-    if (fColl == null || !fColl.isMap())
+    if (!(filter instanceof Map<?,?>)) 
       throw new LuaException("Filter must be a map");
 
-    Collection iColl = Collection.of(details);
-    if (!matchMap(fColl, iColl))
+    if (!deepEquals(filter, details))
       return 0;
     return entry.count;
   }
@@ -46,8 +43,8 @@ public class ComputerUtil {
     if (Objects.equals(fVal, iVal)) return true;
 
     // If both are numbers, compare them as doubles because lua numbers are always doubles
-    if (fVal instanceof Number fn && iVal instanceof Number in){
-      return Double.compare(fn.doubleValue(), in.doubleValue()) == 0;}
+    if (fVal instanceof Number fn && iVal instanceof Number in)
+      return Double.compare(fn.doubleValue(), in.doubleValue()) == 0;
 
     // Convert to collections
     Collection fColl = Collection.of(fVal);

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerUtil.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerUtil.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.simibubi.create.compat.computercraft.implementation.luaObjects.LuaComparable;
 import com.simibubi.create.content.logistics.BigItemStack;
 
 import dan200.computercraft.api.detail.VanillaDetailRegistries;
@@ -39,8 +40,13 @@ public class ComputerUtil {
   }
 
   private static boolean deepEquals(Object fVal, Object iVal) throws LuaException {
-    // Checks primitives, strings and booleans
-    if (Objects.equals(fVal, iVal)) return true;
+    // Checks all non number, Map, and List types
+    if (Objects.equals(iVal, fVal)) return true;
+
+    // Lua Objects can implement LuaComparable to provide a table representation for lazy filtering
+    if (iVal instanceof LuaComparable iStack) {
+      return deepEquals(fVal, iStack.getTableRepresentation());
+    } 
 
     // If both are numbers, compare them as doubles because lua numbers are always doubles
     if (fVal instanceof Number fn && iVal instanceof Number in)

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/luaObjects/LuaComparable.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/luaObjects/LuaComparable.java
@@ -1,0 +1,10 @@
+package com.simibubi.create.compat.computercraft.implementation.luaObjects;
+
+import java.util.Map;
+
+public interface LuaComparable {
+
+  public Map<?,?> getTableRepresentation();
+
+}
+

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/luaObjects/LuaItemStack.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/luaObjects/LuaItemStack.java
@@ -1,0 +1,22 @@
+package com.simibubi.create.compat.computercraft.implementation.luaObjects;
+
+import java.util.Map;
+
+import net.minecraft.world.item.ItemStack;
+
+import dan200.computercraft.api.detail.VanillaDetailRegistries;
+
+public class LuaItemStack implements LuaComparable {
+
+  private final ItemStack stack;
+
+  public LuaItemStack(ItemStack stack) {
+    this.stack = stack;
+  }
+
+  @Override
+  public Map<?, ?> getTableRepresentation() {
+    return VanillaDetailRegistries.ITEM_STACK.getDetails(stack);
+  }
+
+}

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StockTickerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StockTickerPeripheral.java
@@ -84,9 +84,16 @@ public class StockTickerPeripheral extends SyncedPeripheral<StockTickerBlockEnti
 	 */
 	@LuaFunction(mainThread = true)
 	public final int requestFiltered(IArguments arguments) throws LuaException {
-		if (!(arguments.get(0) instanceof Map<?, ?>))
-			return 0;
-		Map<?, ?> filter = (Map<?, ?>) arguments.get(0);
+		if (!(arguments.get(0) instanceof Map<?, ?> filterTable))
+			throw new LuaException("Filter must be a table");
+
+    for (Object key : filterTable.keySet())
+      if (!(key instanceof String)) 
+        throw new LuaException("Filter keys must be strings");
+
+		@SuppressWarnings("unchecked")
+    Map<String, Object> filter = (Map<String, Object>) filterTable;
+    
 		String address;
 		// Computercraft has forced my hand to make this dollar store filter algo
 		List<BigItemStack> validItems = new ArrayList<>();

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StockTickerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StockTickerPeripheral.java
@@ -94,32 +94,27 @@ public class StockTickerPeripheral extends SyncedPeripheral<StockTickerBlockEnti
 		@SuppressWarnings("unchecked")
     Map<String, Object> filter = (Map<String, Object>) filterTable;
     
+    int itemsRequested = Integer.MAX_VALUE;
+    if (arguments.get(2) instanceof Number) {
+      itemsRequested = ((Number) arguments.get(2)).intValue();
+      if (itemsRequested < 1)
+        throw new LuaException("Count must be a positive number or nil for all");
+    }
+    int itemsSent = 0;
+    
 		String address;
 		// Computercraft has forced my hand to make this dollar store filter algo
 		List<BigItemStack> validItems = new ArrayList<>();
-		int totalItemCount = 0;
 		for (BigItemStack entry : blockEntity.getAccurateSummary().getStacks()) {
-			if (ComputerUtil.bigItemStackToLuaTableFilter(entry, filter) > 0) {
-				// limit the number of items pulled from the system equals to the requested
-				// count parameter
-				if (filter.containsKey("count")) {
-					Object count = filter.get("count");
-					if (count instanceof Double) {
-						int maxCount = ((Double) count).intValue();
-						int remainingCount = maxCount - totalItemCount;
-
-						if (remainingCount > 0) {
-							int itemsToAdd = Math.min(remainingCount, entry.count);
-							entry.count = itemsToAdd;
-							totalItemCount += itemsToAdd;
-						} else
-							break;
-					}
-				} else {
-					totalItemCount += entry.count;
-				}
+      int foundItems = ComputerUtil.bigItemStackToLuaTableFilter(entry, filter);
+			if (foundItems > 0) {
+				int toTake = Math.min(foundItems, itemsRequested);
+        itemsRequested -= toTake;
+        itemsSent += toTake;
+        entry.count = toTake;
 				validItems.add(entry);
 			}
+      if (itemsRequested <= 0) break;
 		}
 		if (arguments.get(1) instanceof String)
 			address = arguments.getString(1);
@@ -135,7 +130,7 @@ public class StockTickerPeripheral extends SyncedPeripheral<StockTickerBlockEnti
 		 * PackageOrder(itemsToOrder),
 		 * address, false, new PackageOrder(stacks);
 		 */
-		return totalItemCount;
+		return itemsSent;
 	}
 
 	@LuaFunction(mainThread = true)


### PR DESCRIPTION
Changed bigItemStackToLuaTableFilter / requestFiltered to work with any arbitrary item details from VanillaDetailRegistries.ITEM_STACK.getDetails. Works recursively with primitives, Maps, Lists, and lua objects. 

For maps and lists you can also specify a "_mode" as one of the following:
- Exact: 1:1 match, list must be same size, order, and contents
- Contains: All elements in filter must be in the item, order doesn't matter, args removed from filter as they are found (default)
- Contained: All elements in item must be in the filter, order doesn't matter, args removed from item as they are found

For custom objects you can implement LuaComparable. An example of this for packages is in [this commit](https://github.com/MaxOrtGit/Create/commit/83073e90203917ec5d8857a00b55c9d56acb9c61) where we can request packages within the systems using special data like their address or crafting pattern
